### PR TITLE
Update syntax for match capture

### DIFF
--- a/bindings-python/install.sh
+++ b/bindings-python/install.sh
@@ -4,6 +4,6 @@
 
 # fix relative imports
 # https://github.com/protocolbuffers/protobuf/issues/1491#issuecomment-438138293
-(cd yarrow && sed -i -E 's/^import.*_pb2/from . \0/' *.py)
+(cd yarrow && sed -i -E 's/^import.*_pb2/from . &/' *.py)
 
-python setup.py develop
+python3 setup.py develop


### PR DESCRIPTION
The & capture group syntax should work on all versions of sed; I think \0 is GNU-specific.  I had to change to get it to work.  Tested on macOS Catalina and Ubuntu.

I have python='python3' aliased in .zshrc and .bashrc, but install.sh uses the wrong python in both MacOS and Ubuntu.  I assume the bindings are supposed to work in Python 2, so this edit is a hack pending a better workaround.