### PR TITLE
Fix for intermittent error in Python bindings

### DIFF
--- a/bindings-python/yarrow/wrapper.py
+++ b/bindings-python/yarrow/wrapper.py
@@ -52,5 +52,5 @@ class LibraryWrapper(object):
             *_serialize_proto(analysis, ffi_runtime),
             *_serialize_proto(release, ffi_runtime)
         )
-        serialized_response = ffi_runtime.string(byte_buffer.data, byte_buffer.len)
+        serialized_response = ffi_runtime.buffer(byte_buffer.data, byte_buffer.len)
         return release_pb2.Release.FromString(serialized_response)


### PR DESCRIPTION
Fixes #32 

Protobuf in Python uses FromString and ToString for generic binary byte arrays, but cffi uses null termination in ff.string().  When differentially private release includes a 0 in the serialization, it caused the buffer copied from ffi to be truncated before Protobuf could parse it.  Fix is to use ffi.buffer() then pass to FromString